### PR TITLE
A class's notes page can now access the metadata of notes belonging to it. 

### DIFF
--- a/backend/server.js
+++ b/backend/server.js
@@ -89,7 +89,6 @@ app.post('/get-user-classes', async (req,res)=>{
             userClasses: 1,
             _id: 0
         })
-        console.log(userClasses);
         res.send(userClasses);
     }
     catch(err){
@@ -271,4 +270,48 @@ app.post('/file-upload', upload.single('file'), (req, res, next) => {
         });
     }
 });
+
+app.post('/get-class-files', async (req, res) => {
+
+    console.log("HERE")
+    const className = req.body.className;
+
+    // let className = "";
+
+    // for(let i = 0; i < classNameWithSpecialChars.length; i++){
+    //     if(i < classNameWithSpecialChars.length - 2 && classNameWithSpecialChars.substring(i, i + 2) == "%20"){
+    //         className = className + " ";
+    //         i = i + 3;
+    //     } else {
+    //         className = className + classNameWithSpecialChars[i];
+    //     }
+    // }
+
+    // console.log(className);
+  
+    try {
+        // Debugging function call: findFileById();
+        // const allFiles = await File.find({});
+      const files = await File.find({ className: className });
+      res.json(files);
+    } catch (err) {
+      console.error(err);
+      res.status(500).send('Error retrieving files');
+    }
+  });
+// Debugging function 
+// const idToFind = "6570010f95e3792e65d1fb99"; // Replace with the actual _id
+
+// async function findFileById() {
+//   try {
+//     const file = await File.find({className: "MATH 33B"});
+//     if (file) {
+//       console.log('Found file:', file);
+//     } else {
+//       console.log('No file found with that id');
+//     }
+//   } catch (err) {
+//     console.error('Error finding file:', err);
+//   }
+// }
 

--- a/frontend/src/Notes.js
+++ b/frontend/src/Notes.js
@@ -1,6 +1,8 @@
 import React, { useState, useEffect} from 'react';
 import './Notes.css';
 import AuthService from './services/auth.service';
+
+import axios from 'axios';
 // import ReactDOM from 'react-dom/client'; // interactivity and dynamic changing of page
 // import { Button } from 'react-bootstrap'; 
 // import HeaderComponent from './components/HeaderComponent';
@@ -27,6 +29,27 @@ const examplePDFs = [
 
 const Notes = () => {
   const [curClass, setCurClass] = useState("");
+
+  function fetchFilesForClass(className) {
+    // Encode the class name to ensure the URL is correctly formatted
+    
+  
+    // Construct the URL with the encoded class name
+    const url = `http://localhost:8000/get-class-files`;
+    console.log(url);
+    // Make the GET request
+    axios.post(url, { className: className })
+      .then(response => {
+        console.log('Files:', response.data);
+        // Handle the response data (array of files)
+        
+      })
+      .catch(error => {
+        console.error('Error fetching files:', error);
+        // Handle errors here
+      });
+  }
+
   useEffect(
       ()=> {
         const user = AuthService.getCurrentUser();
@@ -44,13 +67,30 @@ const Notes = () => {
     () => {
       const currentPage = AuthService.getClassPage();
 
+      
+
       if(currentPage){
         console.log(currentPage);
         setCurClass(currentPage);
+
+        // let newString = "";
+
+        // for(let i = 0; i < currentPage.length; i++){
+        //   if(currentPage[i] == " "){
+        //     newString = newString + "%20";
+        //   } else {
+        //     newString = newString + currentPage[i];
+        //   }
+        // }
+
+        fetchFilesForClass(currentPage);
+
       } else {
         // did not update
         console.log("Update didn't carry over - for class name")
       }
+
+      
       
     }, [AuthService.getClassPage()]
 


### PR DESCRIPTION
Example: The CS 35L Notes page (and Notes.js) now has access to the metadata of files belonging to CS 35L alone! 
Meaning, if you navigate to 35L’s notes page and view the Console in the frontend, you’ll see the metadata for all files belonging to that class. Yet to be added to main viewing.